### PR TITLE
支持macOS获取chrome路径，以及pyppeteer不配置路径时会默认下载安装chromium。

### DIFF
--- a/ncatbot/gateway.py
+++ b/ncatbot/gateway.py
@@ -51,8 +51,13 @@ class Websocket:
                     _log.info("websocket连接已建立")
                     while True:
                         message = await ws.recv()
-                        await self.receive(message)
+                        try:
+                            await self.receive(message) # 捕获receive内部的异常，不影响程序持续运行
+                        except Exception as e:
+                            _log.error(f"处理消息时发生错误: {e}")
                 except Exception as e:
+                    _log.error(f"WebSocket 接收消息异常: {e}")
                     raise e
         except Exception as e:
+            _log.error(f"WebSocket 连接错误: {e}")
             raise e


### PR DESCRIPTION
发现问题：qq机器人执行命令发生异常会直接退出进程。原因为抛出异常时跳出了while循环
措施：更改捕获异常的代码

拓展内容：支持macOS获取chrome路径，以及未安装chrome时可自动下载chromium
<img width="1126" alt="image" src="https://github.com/user-attachments/assets/614f2eb3-b624-45f3-b6b4-2a9e87a4390b" />

图片内容展示为未安装chrome后自动安装chromium以及安装chromium后的md命令

尚存在的问题：macOS上通过file://传输图片会报错获取文件名失败，尚不知晓原因。
措施：修改了convert方法，使传输文件时不传输文件路径，而是文件的base64编码。因改动会修改api.py，故未提交。