### PR TITLE
fix:修复了core/message.py中class AtAll的函数to_dict命名错误

### DIFF
--- a/ncatbot/core/message.py
+++ b/ncatbot/core/message.py
@@ -130,7 +130,7 @@ class AtAll(Element):
 
     type = "at"
 
-    def as_dict(self):
+    def to_dict(self):
         return {"type": "at", "data": {"qq": "all"}}
 
 


### PR DESCRIPTION
core/message.py中class AtAll的函数to_dict错误命名为as_dict，根据上下文可以发现正确命名应为to_dict

修改之前遇到报错信息如下：
```
  File "\ncatbot\core\message.py", line 98, in __new__
    return instance.to_dict()
           ^^^^^^^^^^^^^^^^
AttributeError: 'AtAll' object has no attribute 'to_dict'
```
修改后可以正确运行。

![image](https://github.com/user-attachments/assets/ad3100a2-9f09-48cc-a397-f31e7899781a)
