### PR TITLE
fix：PluginLoader传递参数数量错误

### DIFF
--- a/ncatbot/plugin/loader.py
+++ b/ncatbot/plugin/loader.py
@@ -400,7 +400,7 @@ class PluginLoader:
 
 def get_plugin_info(path: str):
     if os.path.exists(path):
-        return PluginLoader(None, None).get_plugin_info(path)
+        return PluginLoader(None).get_plugin_info(path)
     else:
         raise FileNotFoundError(f"dir not found: {path}")
 


### PR DESCRIPTION
- 在使用 PluginLoader 时，构造函数的参数数量传递错误，导致插件发布时出现 TypeError 错误。
- 原始错误信息：TypeError: PluginLoader.__init__() takes 2 positional arguments but 3 were given
- 删除其中一个参数后可以正常使用插件发布功能，但可能无法保证其余部分不会出现潜在问题