### PR TITLE
更新一个错误提示

### DIFF
--- a/ncatbot/adapter/nc/login.py
+++ b/ncatbot/adapter/nc/login.py
@@ -59,7 +59,8 @@ class LoginHandler:
                 LOG.error("连接 WebUI 失败, 以下给出几种可能的解决方案:")
                 if platform.system() == "Windows":
                     LOG.info(
-                        "检查 Windows 安全中心, 查看是否有拦截了 NapCat 启动程序的日志"
+                        "检查 Windows 安全中心, 查看是否有拦截了 NapCat 启动程序的日志。"
+                        "如果你修改了natcat的webui开放端口，请修改启动参数：webui_uri='ws://xxxxx:xxxx'"
                     )
                 LOG.info("开放防火墙的 WebUI 端口 (默认 6099)")
                 exit(1)

--- a/ncatbot/adapter/nc/login.py
+++ b/ncatbot/adapter/nc/login.py
@@ -60,7 +60,7 @@ class LoginHandler:
                 if platform.system() == "Windows":
                     LOG.info(
                         "检查 Windows 安全中心, 查看是否有拦截了 NapCat 启动程序的日志。"
-                        "如果你修改了natcat的webui开放端口，请修改启动参数：webui_uri='ws://xxxxx:xxxx'"
+                        "如果你修改了natcat的网页端开放端口（不是websocket），请修改启动参数：webui_uri='ws://xxxxx:xxxx'"
                     )
                 LOG.info("开放防火墙的 WebUI 端口 (默认 6099)")
                 exit(1)


### PR DESCRIPTION
当natcat的默认启动端口被自定义的时候，会导致检查部分超时报错。但是报错内容没有提示可能是由于用户修改natcat端口导致的。因此增加新的错误提示。方便定位和修复问题。