### PR TITLE
fix: 保留 API 方法元数据

### DIFF
--- a/ncatbot/core/api.py
+++ b/ncatbot/core/api.py
@@ -1,5 +1,6 @@
 import os
 from typing import Union
+from functools import wraps
 
 from ncatbot.adapter import Route
 from ncatbot.core.element import *
@@ -17,6 +18,7 @@ _log = get_log()
 
 
 def report(func):
+    @wraps(func)
     async def wrapper(*args, **kwargs):
         result = await func(*args, **kwargs)
         return check_and_log(result)


### PR DESCRIPTION
由 42b7183c7b46181979ec59955061073cbf694730 导致的，以修复无法序列化嵌套方法