### PR TITLE
Class GroupMessage缺少raw_message

### DIFF
--- a/src/ncatbot/core/message.py
+++ b/src/ncatbot/core/message.py
@@ -74,6 +74,7 @@ class GroupMessage(BaseMessage):
         "sub_type",
         "font",
         "sender",
+        "raw_message"，
         "message_id",
         "message_seq",
         "real_id",


### PR DESCRIPTION
Class GroupMessage 中__slots__ 少了个"raw_message",跟着教程写群指令测试时，发现能收到消息但没反应用log打印msg中也缺少raw_message，添加后能正常使用了