### PR TITLE
支持新版 websockets 并兼容旧版

### DIFF
--- a/src/ncatbot/adapter/net/wsroute.py
+++ b/src/ncatbot/adapter/net/wsroute.py
@@ -4,6 +4,7 @@ import json as j
 import websockets
 
 from ncatbot.utils import config, get_log
+from .connect import connect
 
 _log = get_log()
 
@@ -15,7 +16,7 @@ async def check_websocket(uri):
     :return: 如果可用返回 True，否则返回 False
     """
     try:
-        async with websockets.connect(
+        async with connect(
             f"{uri}",
             extra_headers=(
                 {
@@ -51,7 +52,7 @@ class Route:
 
     async def post(self, path, params=None, json=None):
         # 开大限制到 16MB
-        async with websockets.connect(
+        async with connect(
             self.url, extra_headers=self.headers, max_size=2**24
         ) as ws:
             if params:


### PR DESCRIPTION
新版 websockets （>=14.0）默认用了 asyncio 实现，把 `websockets.connect` 的 `extra_headers` 参数改名为了 `additional_headers`。
这个 PR 可以同时兼容项目默认的 10.4 和新版。