### PR TITLE
修复每次启动使用默认配置文件覆盖的问题

### DIFF
--- a/ncatbot/core/adapter/nc/config.py
+++ b/ncatbot/core/adapter/nc/config.py
@@ -96,20 +96,39 @@ def config_napcat():
                 port = webui_config.get("port", 6099)
                 token = webui_config.get("token", "")
                 ws_listen_ip = webui_config.get("wsListenIp", "0.0.0.0")
+
+            update = False
             if token != ncatbot_config.napcat.webui_token:
-                LOG.warning("WebUI 令牌不匹配, 将修改为 NcatBot 配置的令牌: " + ncatbot_config.napcat.webui_token)
+                update = True
+                LOG.warning(
+                    "WebUI 令牌不匹配, 将修改为 NcatBot 配置的令牌: "
+                    + ncatbot_config.napcat.webui_token
+                )
+                webui_config["token"] = ncatbot_config.napcat.webui_token
             if port != ncatbot_config.napcat.webui_port:
-                LOG.warning("WebUI 端口不匹配, 将修改为 NcatBot 配置的端口: " + str(ncatbot_config.napcat.webui_port))
-                ncatbot_config.napcat.webui_port = port
+                update = True
+                LOG.warning(
+                    "WebUI 端口不匹配, 将修改为 NcatBot 配置的端口: "
+                    + str(ncatbot_config.napcat.webui_port)
+                )
+                webui_config["port"] = ncatbot_config.napcat.webui_port
             if ws_listen_ip != ncatbot_config.napcat.ws_listen_ip:
-                LOG.warning("WebUI 监听 IP 不匹配, 将修改为 NcatBot 配置的监听 IP: " + ncatbot_config.napcat.ws_listen_ip)
+                update = True
+                LOG.warning(
+                    "WebUI 监听 IP 不匹配, 将修改为 NcatBot 配置的监听 IP: "
+                    + ncatbot_config.napcat.ws_listen_ip
+                )
+                webui_config["wsListenIp"] = ncatbot_config.napcat.ws_listen_ip
+            if update:
+                with open(webui_config_path, "w") as f:
+                    json.dump(webui_config, f, indent=4, ensure_ascii=False)
         except FileNotFoundError:
             LOG.warning("第一次运行 WebUI, 将创建 WebUI 配置文件")
             default_webui_config["port"] = ncatbot_config.napcat.webui_port
             default_webui_config["token"] = ncatbot_config.napcat.webui_token
             default_webui_config["wsListenIp"] = ncatbot_config.napcat.ws_listen_ip
-        with open(webui_config_path, "w") as f:
-            json.dump(default_webui_config, f, indent=4, ensure_ascii=False)
+            with open(webui_config_path, "w") as f:
+                json.dump(default_webui_config, f, indent=4, ensure_ascii=False)
 
     config_onebot11()
     config_quick_login()


### PR DESCRIPTION
修复了原始逻辑在每次执行函数时都会强制覆盖配置文件。
将修改了bot的config文件后的行为调整为使用NcatBot的配置修改的NapCat的配置