### PR TITLE
fix: 修复插件加载器中的缩进错误并添加typing-extensions依赖

### DIFF
--- a/ncatbot/plugin_system/loader.py
+++ b/ncatbot/plugin_system/loader.py
@@ -121,7 +121,7 @@ class _ModuleImporter:
                 req = line.strip()
                 if not req or req.startswith("#") or req.startswith("-"):
                     continue
-            self._ensure_package(req)
+                self._ensure_package(req)
 
         def ensure_req_from_pyproject():
             pyproject = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ websockets
 packaging
 rich
 aiofiles
+typing-extensions
 
 colorama>=0.4.6; platform_system == "Windows"
 importlib-metadata>=8.6.1; python_version >= '3.9'


### PR DESCRIPTION
## 1. 修复插件加载器中的缩进错误

self._ensure_package(req)缺少了一级缩进，这导致它只会在循环结束后执行一次  
这导致自动读取插件的requirements.txt安装依赖时，只会安装最后一行的库。

例如，plugins文件夹下一个子插件拥有如下requirements.txt：
```
dashscope
Markdown
openai
```
将只会安装openai

## 2. 引入typing-extensions依赖
因为
https://github.com/liyihao1110/ncatbot/blob/5719604355c0f170c5b7047fb438cddf544460fa/ncatbot/core/client.py#L17
使用了此库