### PR TITLE
修复 event.to_dict() 在有图片时调用两次报错的bug

### DIFF
--- a/ncatbot/core/event/message_segment/message_segment.py
+++ b/ncatbot/core/event/message_segment/message_segment.py
@@ -2,6 +2,7 @@ import os
 import time
 import httpx
 import urllib.parse
+import copy
 from dataclasses import dataclass, field, fields
 from typing import Literal, Union, Any, TYPE_CHECKING, TypeVar, Dict, Type, List
 from ....utils import get_log, run_coroutine, NcatBotError, status
@@ -200,8 +201,11 @@ class DownloadableMessageSegment(MessageSegment):
         return filename
 
     def to_dict(self):
-        self.file = convert_uploadable_object(self.file)
-        return super().to_dict()
+        # 不修改本身的 file 属性，提供一个转换后的副本
+        copy_self = copy.deepcopy(self)
+        copy_self.file = convert_uploadable_object(copy_self.file)
+        # 调用父类的to_dict()方法，防止无限递归
+        return super(DownloadableMessageSegment, copy_self).to_dict()
 
     def __post_init__(self):
         pass


### PR DESCRIPTION
根据实际测试，导致错误的根本原因是因为**to_dict方法修改了自身的file属性**，导致第二次to_dict调用时将修改后的file属性传入convert导致出现了非法的path字符串。
pr通过创建自身的副本修改这一file，最终return结果理论和原函数相同，同时在多次调用时不会引起上述问题。
#219 